### PR TITLE
Fix 'object must be a string or a function'

### DIFF
--- a/cft_sidecar.yaml
+++ b/cft_sidecar.yaml
@@ -781,7 +781,7 @@ Resources:
                 log_group: !Ref CloudwatchLogGroup
                 tls_skip_verify: 'tls'
                 secrets_location: !Sub '/cyral/sidecars/${SidecarId}/secrets'
-                load_balancer_tls_ports: !If [loadBalancerCertificateArnNotEmpty, 443, !Ref AWS::NoValue]
+                load_balancer_tls_ports: !If [loadBalancerCertificateArnNotEmpty, 443, ""]
                 sidecar_tls_certificate_secret_arn: !Ref SidecarCreatedCertificateSecret
                 sidecar_ca_certificate_secret_arn: !Ref SidecarCACertificateSecret
             post: |


### PR DESCRIPTION
There was an error with the template when loadbalancer parameter was not set:
![image](https://github.com/cyral-quickstart/quickstart-sidecar-cloudformation-ec2/assets/37452507/594e4b9d-1304-47b3-a40d-80dff6052a17)

This PR solves it as we validated:
![image](https://github.com/cyral-quickstart/quickstart-sidecar-cloudformation-ec2/assets/37452507/5fec7cc4-9de4-4152-a687-2f754827c309)

