### PR TITLE
Adding in post install tasks for IAM Roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,4 @@ Instructions for advanced configurations are available for the following topics:
 
 * [Sidecar certificates](./docs/certificates.md)
 * [Sidecar instance metrics](./docs/metrics.md)
+* [IAM Roles](./docs/iam.md)

--- a/docs/iam.md
+++ b/docs/iam.md
@@ -1,0 +1,5 @@
+# Configuring IAM Roles Cloudformation AWS EC2 sidecars
+
+In order for the Sidecar to provide access to AWS resources such as S3 and DynamoDB, the sidecar needs to be granted the `sts:AssumeRole` action on roles that grant users access to S3 and DynamoDB related resources.
+
+Granting the `sts:AssumeRole` action is a manual step that must be performed after you have deployed your sidecar. You can refer to the [Make AWS IAM role settings](https://cyral.com/docs/manage-repositories/s3/s3-sso/#make-aws-iam-role-settings) section of the `SSO for S3` page in the [Cyral Docs](https://cyral.com/docs) for additional details.

--- a/docs/iam.md
+++ b/docs/iam.md
@@ -1,5 +1,9 @@
 # Configuring IAM Roles Cloudformation AWS EC2 sidecars
 
-In order for the Sidecar to provide access to AWS resources such as S3 and DynamoDB, the sidecar needs to be granted the `sts:AssumeRole` action on roles that grant users access to S3 and DynamoDB related resources.
+In order for the Sidecar to provide access to AWS resources such as S3 and DynamoDB, the sidecar needs to be granted the `sts:AssumeRole` action on roles that grant users access to AWS related repositories such as:
+
+* S3
+* DynamoDB
+* RDS instances using IAM based authentication
 
 Granting the `sts:AssumeRole` action is a manual step that must be performed after you have deployed your sidecar. You can refer to the [Make AWS IAM role settings](https://cyral.com/docs/manage-repositories/s3/s3-sso/#make-aws-iam-role-settings) section of the `SSO for S3` page in the [Cyral Docs](https://cyral.com/docs) for additional details.


### PR DESCRIPTION
This adds some documentation regarding steps that need to be performed for Cyral sidecar deployments that will hand IAM based authentication