### PR TITLE
ENG-13040: Add extra IAM, pre and post hooks configuration

### DIFF
--- a/cft_sidecar.yaml
+++ b/cft_sidecar.yaml
@@ -37,6 +37,7 @@ Metadata:
       - SidecarTLSCertificateSecretArn
       - SidecarCACertificateSecretArn
       - UseSingleContainer
+      - IAMPolicies
     - Label:
         default: 'High Availability'
       Parameters:
@@ -246,6 +247,11 @@ Parameters:
       - "true"
       - "false"
 
+  IAMPolicies:
+    Type: CommaDelimitedList
+    Description: (Optional) List of IAM policies ARNs that will be attached to the sidecar IAM role (Comma Delimited List)
+    Default: ""
+
   CustomUserDataPre:
     Type: String
     Description: (Optional) Ancillary consumer supplied user-data script. Provide Bash script commands to be executed before the sidecar installation. Ex:"echo 'TEST'".
@@ -265,6 +271,7 @@ Conditions:
   useCustomTag: !Not [!Equals [!Ref CustomTag, '']]
   hasSSHKeyName: !Not [!Equals [!Ref SSHKeyName, '']]
   deployLoadBalancer: !Equals [!Ref DeployLoadBalancer, 'true']
+  mustAttachIAMPolicies: !Not [!Equals [!Join ["", !Ref IAMPolicies], ""]]
   loadBalancerCertificateArnNotEmpty: !And [!Not [!Equals [!Ref LoadBalancerCertificateArn, '']], !Condition deployLoadBalancer]
   loadBalancerCertificateArnEmpty: !And [!Equals [!Ref LoadBalancerCertificateArn, ''], !Condition deployLoadBalancer]
   sidecarDNSNameNotEmpty: !Not [!Equals [!Ref SidecarDNSName, '']]
@@ -394,6 +401,7 @@ Resources:
                 - ec2.amazonaws.com
             Action:
               - "sts:AssumeRole"
+      ManagedPolicyArns: !If [mustAttachIAMPolicies, !Ref IAMPolicies, !Ref AWS::NoValue]
 
   SidecarHostPolicy:
     Type: "AWS::IAM::Policy"

--- a/cft_sidecar.yaml
+++ b/cft_sidecar.yaml
@@ -45,6 +45,12 @@ Metadata:
       - AsgMax
       - AsgDesired
     - Label:
+        default: 'Custom User Data'
+      Parameters:
+      - CustomUserDataPre
+      - CustomUserDataPreSidecarStart
+      - CustomUserDataPost
+    - Label:
         default: 'Snowflake Configuration'
       Parameters:
       - IdPSSOLoginURL
@@ -239,6 +245,21 @@ Parameters:
     AllowedValues:
       - "true"
       - "false"
+
+  CustomUserDataPre:
+    Type: String
+    Description: (Optional) Ancillary consumer supplied user-data script. Provide Bash script commands to be executed before the sidecar installation. Ex:"echo 'TEST'".
+    Default: ""
+
+  CustomUserDataPreSidecarStart:
+    Type: String
+    Description: (Optional) Ancillary consumer supplied user-data script. Provide Bash script commands to be executed before the sidecar starts. Ex:"echo 'TEST'"
+    Default: ""
+
+  CustomUserDataPost:
+    Type: String
+    Description: (Optional) Ancillary consumer supplied user-data script. Provide Bash script commands to be executed after the sidecar starts. Ex:"echo 'TEST'"
+    Default: ""
 
 Conditions:
   useCustomTag: !Not [!Equals [!Ref CustomTag, '']]
@@ -462,8 +483,11 @@ Resources:
             #!/bin/bash -e
 
             ${functions}
+            ${CustomUserDataPre}
             ${pre}
+            ${CustomUserDataPreSidecarStart}
             ${post}
+            ${CustomUserDataPost}
 
             /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource AutoScalingGroupSidecar --region ${AWS::Region}
           - functions:


### PR DESCRIPTION
# Description

Adds custom pre and post hook options when deploying sidecars to allow for
authentication to private image registries. Also adds extra IAM policies to
attach to the role for the asg.

## Testing

Deployed a sidecar whilst authenticating to a private image registry with
an extra IAM policy.
