### PR TITLE
Fixes comparison for determining docker login method

### DIFF
--- a/cft_sidecar.yaml
+++ b/cft_sidecar.yaml
@@ -686,7 +686,7 @@ Resources:
                 function registry_login () {
                     echo "Container Registry Login..."
                     local key=$GCR_REG_KEY
-                    if [[ ${ContainerRegistry} == *"aws"* ]]; then
+                    if [[ ${ContainerRegistry} == *"amazonaws"* ]]; then
                         echo "(login): Logging in to AWS ECR..."
                         aws ecr get-login-password --region ${AWS::Region} | docker login --username AWS --password-stdin ${ContainerRegistry}
                     elif [ -n "$key" ]; then


### PR DESCRIPTION
# Description

Changes comparison for determining when you should log in to the docker
registry.

## Testing

Deployed a sidecar with no custom docker registry configuration, using the
public registry and it correctly did _not_ try to log in to the registry.

Deployed a sidecar with a ecr URL (cyral's private registry) and it correctly
authenticated with the AWS cli.
