### PR TITLE
ENG-12957: Add section for S3 File Browser configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,13 @@ To configure the sidecar to work on the S3 File Browser, set the following param
   - `LoadBalancerCertificateArn`: Add the ARN of the TLS certificate in
     AWS Certificate Manager.
 
-For sidecars with support for S3, it is also necessary to
-attach the list of IAM Policies giving the sidecar all the required
-permissions to assume IAM roles used to communicate to S3.
+For sidecars with support for S3, it is also necessary to create an IAM
+role with permissions to access the target S3 buckets. This role must
+have a trust relationship with the sidecar role created as part of this template,
+so the sidecar can use it to access the target S3 buckets. The arn of the IAM
+role with the S3 access permissions must then be provided to the 
+control plane as part of the repository configuration.
 
-All the CloudFormation parameters used above are documented in the 
-[Cyral sidecar CloudFormation module for AWS EC2](https://github.com/cyralinc/sidecar-cloudformation-ec2/). 
 For more details about the S3 File Browser configuration, check the 
 [Enable the S3 File Browser](https://cyral.com/docs/how-to/enable-s3-browser) 
 documentation.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,30 @@ allowed inbound rules in the databases' security groups. If the databases do not
 analyze what is the proper networking configuration to allow connectivity from the EC2
 instances to the protected databases.
 
+#### Enable the S3 File Browser
+
+To configure the sidecar to work on the S3 File Browser, set the following parameters in your CloudFormation stack:
+
+  - `SidecarDNSName`: Add the sidecar custom CNAME.
+  - `SidecarDNSHostedZoneId`: Add the Route53 hosted zone ID.
+    - If `SidecarDNSHostedZoneId` is omitted, the `SidecarDNSName` won’t
+      be automatically created, and the sidecar alias will need to be
+      created after the deployment: Add a CNAME or A record for the
+      sidecar.
+  - `LoadBalancerCertificateArn`: Add the ARN of the TLS certificate in
+    AWS Certificate Manager.
+  - `LoadBalancerTLSPorts`: Add 443 to the list.
+
+For sidecars with support for S3, it is also necessary to
+attach the list of IAM Policies giving the sidecar all the required
+permissions to assume IAM roles used to communicate to S3.
+
+All the CloudFormation parameters used above are documented in the 
+[Cyral sidecar CloudFormation module for AWS EC2](https://github.com/cyralinc/sidecar-cloudformation-ec2/). 
+For more details about the S3 File Browser configuration, check the 
+[Enable the S3 File Browser](https://cyral.com/docs/how-to/enable-s3-browser) 
+documentation.
+
 ### Parameters
 
 See the full list of parameters in the parameters section of the [deployment template](./cft_sidecar.yaml).

--- a/README.md
+++ b/README.md
@@ -107,13 +107,8 @@ instances to the protected databases.
 To configure the sidecar to work on the S3 File Browser, set the following parameters in your CloudFormation stack:
 
   - `SidecarDNSName`: Add the sidecar custom CNAME.
-  - `SidecarDNSHostedZoneId`: Add the Route53 hosted zone ID.
-    - If `SidecarDNSHostedZoneId` is omitted, the `SidecarDNSName` won’t
-      be automatically created, and the sidecar alias will need to be
-      created after the deployment: See [Add a CNAME or A record for the sidecar](https://cyral.com/docs/sidecars/manage/alias).
   - `LoadBalancerCertificateArn`: Add the ARN of the TLS certificate in
     AWS Certificate Manager.
-  - `LoadBalancerTLSPorts`: Add 443 to the list.
 
 For sidecars with support for S3, it is also necessary to
 attach the list of IAM Policies giving the sidecar all the required

--- a/README.md
+++ b/README.md
@@ -127,6 +127,6 @@ Learn more in the [sidecar upgrade procedures](https://cyral.com/docs/sidecars/m
 
 Instructions for advanced configurations are available for the following topics:
 
+* [Enable the S3 File Browser](./docs/s3-browser.md)
 * [Sidecar certificates](./docs/certificates.md)
 * [Sidecar instance metrics](./docs/metrics.md)
-* [Enable the S3 File Browser](./docs/s3-browser.md)

--- a/README.md
+++ b/README.md
@@ -102,25 +102,6 @@ allowed inbound rules in the databases' security groups. If the databases do not
 analyze what is the proper networking configuration to allow connectivity from the EC2
 instances to the protected databases.
 
-#### Enable the S3 File Browser
-
-To configure the sidecar to work on the S3 File Browser, set the following parameters in your CloudFormation stack:
-
-  - `SidecarDNSName`: Add the sidecar custom CNAME.
-  - `LoadBalancerCertificateArn`: Add the ARN of the TLS certificate in
-    AWS Certificate Manager.
-
-For sidecars with support for S3, it is also necessary to create an IAM
-role with permissions to access the target S3 buckets. This role must
-have a trust relationship with the sidecar role created as part of this template,
-so the sidecar can use it to access the target S3 buckets. The arn of the IAM
-role with the S3 access permissions must then be provided to the 
-control plane as part of the repository configuration.
-
-For more details about the S3 File Browser configuration, check the 
-[Enable the S3 File Browser](https://cyral.com/docs/how-to/enable-s3-browser) 
-documentation.
-
 ### Parameters
 
 See the full list of parameters in the parameters section of the [deployment template](./cft_sidecar.yaml).
@@ -148,3 +129,4 @@ Instructions for advanced configurations are available for the following topics:
 
 * [Sidecar certificates](./docs/certificates.md)
 * [Sidecar instance metrics](./docs/metrics.md)
+* [Enable the S3 File Browser](./docs/s3-browser.md)

--- a/README.md
+++ b/README.md
@@ -110,8 +110,7 @@ To configure the sidecar to work on the S3 File Browser, set the following param
   - `SidecarDNSHostedZoneId`: Add the Route53 hosted zone ID.
     - If `SidecarDNSHostedZoneId` is omitted, the `SidecarDNSName` won’t
       be automatically created, and the sidecar alias will need to be
-      created after the deployment: Add a CNAME or A record for the
-      sidecar.
+      created after the deployment: See [Add a CNAME or A record for the sidecar](https://cyral.com/docs/sidecars/manage/alias).
   - `LoadBalancerCertificateArn`: Add the ARN of the TLS certificate in
     AWS Certificate Manager.
   - `LoadBalancerTLSPorts`: Add 443 to the list.

--- a/docs/s3-browser.md
+++ b/docs/s3-browser.md
@@ -1,0 +1,18 @@
+#### Enable the S3 File Browser
+
+To configure the sidecar to work on the S3 File Browser, set the following parameters in your CloudFormation stack:
+
+  - `SidecarDNSName`: Add the sidecar custom CNAME.
+  - `LoadBalancerCertificateArn`: Add the ARN of the TLS certificate in
+    AWS Certificate Manager.
+
+For sidecars with support for S3, it is also necessary to create an IAM
+role with permissions to access the target S3 buckets. This role must
+have a trust relationship with the sidecar role created as part of this template,
+so the sidecar can use it to access the target S3 buckets. The arn of the IAM
+role with the S3 access permissions must then be provided to the 
+control plane as part of the repository configuration.
+
+For more details about the S3 File Browser configuration, check the 
+[Enable the S3 File Browser](https://cyral.com/docs/how-to/enable-s3-browser) 
+documentation.


### PR DESCRIPTION
Add a section for S3 File Browser configuration, instructing how to configure the corresponding sidecar template parameters to work with S3 File Browser.