### PR TITLE
Move to single container

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Learn more in the [sidecar upgrade procedures](https://cyral.com/docs/sidecars/m
 
 Instructions for advanced configurations are available for the following topics:
 
+* [Bring your own secret](./docs/byos.md)
 * [Enable the S3 File Browser](./docs/s3-browser.md)
 * [Sidecar certificates](./docs/certificates.md)
 * [Sidecar instance metrics](./docs/metrics.md)

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Deploying a test sidecar is the easiest way to have a sidecar up and running to
 understand the basic concepts of our product.
 
 In case the databases you are protecting with the Cyral sidecar also live on AWS, make sure to
-add the sidecar security group (see output parameter `SidecarSecurityGroupID`) to the list of
+add the sidecar security group (see output parameter `SecurityGroupID`) to the list of
 allowed inbound rules in the databases' security groups. If the databases do not live on AWS,
 analyze what is the proper networking configuration to allow connectivity from the EC2
 instances to the protected databases.
@@ -95,7 +95,7 @@ In order to properly secure your sidecar, define appropriate inbound CIDRs using
 variables documentation in the downloaded file for more information.
 
 In case the databases you are protecting with the Cyral sidecar also live on AWS, make sure to
-add the sidecar security group (see output parameter `SidecarSecurityGroupID`) to the list of
+add the sidecar security group (see output parameter `SecurityGroupID`) to the list of
 allowed inbound rules in the databases' security groups. If the databases do not live on AWS,
 analyze what is the proper networking configuration to allow connectivity from the EC2
 instances to the protected databases.

--- a/cft_sidecar.yaml
+++ b/cft_sidecar.yaml
@@ -1244,15 +1244,15 @@ Resources:
           - !Ref AWS::NoValue
 
 Outputs:
-  SidecarDNS:
+  DNS:
     Description: Sidecar DNS name
     Value: !If [deployLoadBalancer, !GetAtt LoadBalancer.DNSName, "NA"]
 
-  SidecarLoadBalancerDNS:
+  LoadBalancerDNS:
     Description: Sidecar load balancer DNS name
     Value: !If [deployLoadBalancer, !GetAtt LoadBalancer.DNSName, "NA"]
 
-  SidecarSecurityGroupID:
+  SecurityGroupID:
     Description: Sidecar security group id
     Value: !Ref SidecarSecurityGroup
 

--- a/cft_sidecar.yaml
+++ b/cft_sidecar.yaml
@@ -586,8 +586,9 @@ Resources:
 
                 function load_idp_certs() {
                     echo "Loading IDP certificates..."
-                    SIDECAR_IDP_PUBLIC_CERT="$(echo "$secret" | jq -r .sidecarPublicIdpCertificate)"
-                    SIDECAR_IDP_PRIVATE_KEY="$(echo "$secret" | jq -r .sidecarPrivateIdpKey)"
+                    IDP_CERTIFICATE=$(echo "$secret" | jq -r 'select(.idpCertificate != null) | .idpCertificate')
+                    SIDECAR_IDP_PUBLIC_CERT=$(echo "$secret" | jq -r 'select(.sidecarPublicIdpCertificate != null) | .sidecarPublicIdpCertificate')
+                    SIDECAR_IDP_PRIVATE_KEY=$(echo "$secret" | jq -r 'select(.sidecarPrivateIdpKey != null) | .sidecarPrivateIdpKey')
                 }
 
                 function fetch_hostname() {
@@ -771,7 +772,7 @@ Resources:
 
                 TLS_SKIP_VERIFY=${tls_skip_verify}
 
-                CYRAL_IDP_CERTIFICATE=${IdPCertificate}
+                CYRAL_IDP_CERTIFICATE=${!IDP_CERTIFICATE}
                 CYRAL_NGINX_RESOLVER=$NGINX_RESOLVER
                 CYRAL_SSO_LOGIN_URL=${IdPSSOLoginURL}
 
@@ -1232,7 +1233,7 @@ Resources:
     Properties:
       Description: Cyral Sidecar secret with client id, secret and container registry key.
       Name: !Sub '/cyral/sidecars/${SidecarId}/secrets'
-      SecretString: !Sub '{"clientId":"${ClientId}", "clientSecret": "${ClientSecret}", "sidecarPublicIdpCertificate": "${SidecarPublicIdPCertificate}", "sidecarPrivateIdpKey": "${SidecarPrivateIdPKey}"}'
+      SecretString: !Sub '{"clientId":"${ClientId}", "clientSecret": "${ClientSecret}", "sidecarPublicIdpCertificate": "${SidecarPublicIdPCertificate}", "sidecarPrivateIdpKey": "${SidecarPrivateIdPKey}", "idpCertificate": "${IdPCertificate}"}'
       KmsKeyId: !Ref AWS::NoValue
       Tags:
         - Key: "Stack"

--- a/cft_sidecar.yaml
+++ b/cft_sidecar.yaml
@@ -265,8 +265,8 @@ Conditions:
   loadBalancerCertificateArnNotEmpty: !And [!Not [!Equals [!Ref LoadBalancerCertificateArn, '']], !Condition deployLoadBalancer]
   loadBalancerCertificateArnEmpty: !And [!Equals [!Ref LoadBalancerCertificateArn, ''], !Condition deployLoadBalancer]
   dnsNameNotEmpty: !Not [!Equals [!Ref DNSName, '']]
-  hasSecretArn: !Not [!Equals [!Ref SecretArn, '']]
   hasNamePrefix: !Not [!Equals [!Ref NamePrefix, '']]
+  shouldCreateSecret: !Equals [!Ref SecretArn, '']
   tlsCertificateSecretArnEmpty: !Equals [!Ref TLSCertificateSecretArn, '']
   tlsCertificateSecretArnNotEmpty: !Not [!Condition tlsCertificateSecretArnEmpty]
   tlsCertificateRoleArnEmpty: !Equals [!Ref TLSCertificateRoleArn, '']
@@ -417,19 +417,10 @@ Resources:
             Resource:
               - !Sub 'arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/cyral/*'
               - !Sub
-                - 'arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${secret_arn}*'
-                - secret_arn: !If [hasSecretArn, !Ref SecretArn, !Ref SMSidecarSecret]
+                - '${secret_arn}*'
+                - secret_arn: !If [shouldCreateSecret, !Ref SMSidecarSecret, !Ref SecretArn]
               - !If [tlsCertificateDoNotAssumeRole, !Ref TLSCertificateSecretArn, !Ref AWS::NoValue]
               - !If [caCertificateDoNotAssumeRole, !Ref CACertificateSecretArn, !Ref AWS::NoValue]
-            Effect: Allow
-          - Action:
-              - "ecr:GetAuthorizationToken"
-            Resource: "*"
-            Effect: Allow
-          - Action:
-              - "ecr:BatchGetImage"
-              - "ecr:GetDownloadUrlForLayer"
-            Resource: !Sub "arn:${AWS::Partition}:ecr:*:${AWS::AccountId}:repository/*"
             Effect: Allow
           - Fn::If:
             - tlsCertificateMustAssumeRole
@@ -564,7 +555,7 @@ Resources:
                       export AWS_SECRET_ACCESS_KEY=$(echo "$assume_role_result" | jq -r .Credentials.SecretAccessKey)
                       export AWS_SESSION_TOKEN=$(echo "$assume_role_result" | jq -r .Credentials.SessionToken)
                     fi
-                    aws --region ${AWS::Region} secretsmanager get-secret-value --secret-id $secret_arn --query SecretString --output text
+                    aws --region ${aws_region} secretsmanager get-secret-value --secret-id $secret_arn --query SecretString --output text
                   )
                 }
 
@@ -615,8 +606,11 @@ Resources:
                 function get_token () {
                     echo "Getting Control Plane Token using port $1..."
                     local url_token="https://${ControlPlane}:$1/v1/users/oidc/token"
-                    token=$(curl --no-progress-meter --fail-with-body --request POST "$url_token" -d grant_type=client_credentials -d client_id="$SIDECAR_CLIENT_ID" -d client_secret="$SIDECAR_CLIENT_SECRET" 2>&1)
+                    local e_state=$(set +o | grep errexit) # Store the current errexit state
+                    set +e
+                    token=$(curl --connect-timeout 60 --no-progress-meter --fail-with-body --request POST "$url_token" -d grant_type=client_credentials -d client_id="$SIDECAR_CLIENT_ID" -d client_secret="$SIDECAR_CLIENT_SECRET" 2>&1)
                     token_error=$(echo $?)
+                    eval "$e_state" # Restore the errexit state
                 }
 
                 function get_sidecar_version () {
@@ -643,11 +637,11 @@ Resources:
 
                 function registry_login () {
                     echo "Container Registry Login..."
-                    if [[ ${ContainerRegistry} == *"amazonaws"* ]]; then
+                    if [[ ${container_registry} == *"aws"* ]] && [[ ${container_registry} != *"public.ecr.aws"* ]]; then
                         echo "(login): Logging in to AWS ECR..."
-                        aws ecr get-login-password --region ${AWS::Region} | docker login --username AWS --password-stdin ${ContainerRegistry}
+                        aws ecr get-login-password --region $aws_region} | docker login --username AWS --password-stdin ${container_registry}
                     else
-                        echo "(login): Won't log in automatically to any image registry. Image registry set to: ${ContainerRegistry}"
+                        echo "(login): Won't log in automatically to any image registry. Image registry set to: ${container_registry}"
                     fi
                 }
 
@@ -668,17 +662,19 @@ Resources:
                 function launch () {
                     echo "Starting sidecar..."
                     cd /home/ec2-user
-                    SIDECAR_IMAGE=${ContainerRegistry}/cyral-sidecar:$SIDECAR_VERSION
+                    SIDECAR_IMAGE=${container_registry}/cyral-sidecar:$SIDECAR_VERSION
                     retry docker pull -q $SIDECAR_IMAGE
                     retry docker run -d --name sidecar --network=host --log-driver=local --log-opt max-size=500m --restart=unless-stopped --env-file .env $SIDECAR_IMAGE
                     if ! containerCheck "sidecar"; then
                       echo "--> Problem with sidecar! Inspect the logs to diagnose the issue. <--"
                     fi
                 }
-              - sidecar_tls_certificate_secret_arn: !If [tlsCertificateSecretArnNotEmpty, !Ref TLSCertificateSecretArn, '']
-                sidecar_ca_certificate_secret_arn: !If [caCertificateSecretArnNotEmpty, !Ref CACertificateSecretArn, '']
-                secret_arn: !If [hasSecretArn, !Ref SecretArn, !Ref SMSidecarSecret]
+              - aws_region: !Ref AWS::Region
+                container_registry: !Ref ContainerRegistry
+                secret_arn: !If [shouldCreateSecret, !Ref SMSidecarSecret, !Ref SecretArn]
                 secret_role_arn: !Ref SecretRoleArn
+                sidecar_ca_certificate_secret_arn: !If [caCertificateSecretArnNotEmpty, !Ref CACertificateSecretArn, '']
+                sidecar_tls_certificate_secret_arn: !If [tlsCertificateSecretArnNotEmpty, !Ref TLSCertificateSecretArn, '']
             pre:
               !Sub
               - |
@@ -715,7 +711,7 @@ Resources:
                 recycle_status=\$(echo \$health | jq -r .components.recycle.status)
                 if [ \$recycle_status == "degraded" ]; then
                   echo "Sidecar instance has been marked for recycling - setting EC2 health to 'Unhealthy'"
-                  aws autoscaling set-instance-health --region ${AWS::Region} --instance-id \$INSTANCE_ID --no-should-respect-grace-period --health-status Unhealthy
+                  aws autoscaling set-instance-health --region ${aws_region} --instance-id \$INSTANCE_ID --no-should-respect-grace-period --health-status Unhealthy
                 fi
                 EOF
 
@@ -769,8 +765,8 @@ Resources:
                 IS_DYNAMIC_VERSION=$IS_DYNAMIC_VERSION
                 IS_RECYCLABLE=true
 
-                AWS_REGION=${AWS::Region}
-                AWS_ACCOUNT_ID=${AWS::AccountId}
+                AWS_REGION=${aws_region}
+                AWS_ACCOUNT_ID=${aws_account_id}
                 LOG_GROUP_NAME=${log_group_name}
 
                 TLS_SKIP_VERIFY=${tls_skip_verify}
@@ -795,7 +791,7 @@ Resources:
                 CYRAL_SIDECAR_CLIENT_ID=${!SIDECAR_CLIENT_ID}
                 CYRAL_SIDECAR_CLIENT_SECRET=${!SIDECAR_CLIENT_SECRET}
                 CYRAL_SIDECAR_CLOUD_PROVIDER=aws
-                CYRAL_SIDECAR_DEPLOYMENT_PROPERTIES='{ \"account-id\": \"${AWS::AccountId}\",\"region\": \"${AWS::Region}\",\"deployment-type\": \"cloudformation-ec2\"}'
+                CYRAL_SIDECAR_DEPLOYMENT_PROPERTIES='{ \"account-id\": \"${aws_account_id}\",\"region\": \"${aws_region}\",\"deployment-type\": \"cloudformation-ec2\"}'
                 CYRAL_SIDECAR_ENDPOINT=$CYRAL_SIDECAR_ENDPOINT
                 CYRAL_SIDECAR_INSTANCE_ID=$INSTANCE_ID
                 CYRAL_SIDECAR_VERSION=$SIDECAR_VERSION
@@ -803,12 +799,14 @@ Resources:
                 CYRAL_REPOSITORIES_SUPPORTED=${repositories_supported}
 
                 EOF
-              - sidecar_endpoint: !If [deployLoadBalancer, !If [dnsNameNotEmpty, !Ref DNSName, !GetAtt LoadBalancer.DNSName], ""]
-                log_group_name: !Ref CloudwatchLogGroup
-                tls_skip_verify: 'tls'
-                secret_arn: !If [hasSecretArn, !Ref SecretArn, !Ref SMSidecarSecret]
+              - aws_account_id: !Ref AWS::AccountId
+                aws_region: !Ref AWS::Region
                 load_balancer_tls_ports: !If [loadBalancerCertificateArnNotEmpty, 443, '']
+                log_group_name: !Ref CloudwatchLogGroup
                 repositories_supported: !Ref RepositoriesSupported
+                secret_arn: !If [shouldCreateSecret, !Ref SMSidecarSecret, !Ref SecretArn]
+                sidecar_endpoint: !If [deployLoadBalancer, !If [dnsNameNotEmpty, !Ref DNSName, !GetAtt LoadBalancer.DNSName], ""]
+                tls_skip_verify: 'tls'
             post: |
               launch
 
@@ -1230,9 +1228,10 @@ Resources:
 
   SMSidecarSecret:
     Type: AWS::SecretsManager::Secret
+    Condition: shouldCreateSecret
     Properties:
       Description: Cyral Sidecar secret with client id, secret and container registry key.
-      Name: !If [hasSecretArn, !Ref SecretArn, !Sub '/cyral/sidecars/${SidecarId}/secrets']
+      Name: !Sub '/cyral/sidecars/${SidecarId}/secrets'
       SecretString: !Sub '{"clientId":"${ClientId}", "clientSecret": "${ClientSecret}", "sidecarPublicIdpCertificate": "${SidecarPublicIdPCertificate}", "sidecarPrivateIdpKey": "${SidecarPrivateIdPKey}"}'
       KmsKeyId: !Ref AWS::NoValue
       Tags:

--- a/cft_sidecar.yaml
+++ b/cft_sidecar.yaml
@@ -231,6 +231,7 @@ Parameters:
   NamePrefix:
     Type: String
     Description: "Prefix for names of the AWS resources created. Maximum length is 24 characters."
+    Default: ""
 
   IAMPolicies:
     Type: CommaDelimitedList

--- a/cft_sidecar.yaml
+++ b/cft_sidecar.yaml
@@ -25,19 +25,18 @@ Metadata:
       - SidecarInstanceType
       - AmiId
       - LoadBalancerCertificateArn
-      - SidecarDNSName
+      - DNSName
       - LoadBalancerScheme
       - AssociatePublicIpAddress
       - ContainerRegistry
-      - ContainerRegistryUsername
-      - ContainerRegistryKey
-      - SecretsLocation
-      - SidecarTLSCertificateRoleArn
-      - SidecarCACertificateRoleArn
-      - SidecarTLSCertificateSecretArn
-      - SidecarCACertificateSecretArn
-      - UseSingleContainer
+      - SecretArn
+      - SecretRoleArn
+      - CACertificateRoleArn
+      - CACertificateSecretArn
+      - TLSCertificateRoleArn
+      - TLSCertificateSecretArn
       - IAMPolicies
+      - RepositoriesSupported
     - Label:
         default: 'High Availability'
       Parameters:
@@ -67,13 +66,13 @@ Parameters:
     Default: false
     ConstraintDescription: must specify 'true' or 'false'.
 
-  SidecarTLSCertificateRoleArn:
+  TLSCertificateRoleArn:
     Description: "(Optional) ARN of an AWS IAM Role to assume when reading the TLS certificate."
     Type: String
     Default: ""
     AllowedPattern: "^(|arn:.+)$"
 
-  SidecarCACertificateRoleArn:
+  CACertificateRoleArn:
     Description: "(Optional) ARN of an AWS IAM Role to assume when reading the CA certificate."
     Type: String
     Default: ""
@@ -85,18 +84,7 @@ Parameters:
     AllowedPattern: ".+"
     Default: "public.ecr.aws/cyral"
 
-  ContainerRegistryUsername:
-    Description: "Username to authenticate to the container registry."
-    Type: String
-    Default: ""
-
-  ContainerRegistryKey:
-    NoEcho: true
-    Description: "Corresponding key for the user name provided to authenticate to the container registry."
-    Type: String
-    Default: ""
-
-  SidecarDNSName:
+  DNSName:
     Description: "(Optional) Fully qualified domain name that will be automatically created/updated to reference the sidecar LB"
     Type: String
     Default: ""
@@ -133,12 +121,12 @@ Parameters:
     Description: (Optional) ARN of SSL certificate that will be used for client connections to Snowflake or S3 Browser.
     Default: ""
 
-  SidecarTLSCertificateSecretArn:
+  TLSCertificateSecretArn:
     Type: String
     Description: (Optional) ARN of TLS certificate needed by the sidecar to terminate TLS connections.
     Default: ""
 
-  SidecarCACertificateSecretArn:
+  CACertificateSecretArn:
     Type: String
     Description: (Optional) ARN of CA certificate needed by the sidecar to sign proxied TLS connections.
     Default: ""
@@ -150,8 +138,13 @@ Parameters:
     Default: 'internal'
     ConstraintDescription: must specify 'internal' or 'internet-facing'.
 
-  SecretsLocation:
-    Description: "(Optional) Location in AWS Secrets Manager to store `SidecarClientID`, `SidecarClientSecret` and `ContainerRegistryKey`. If unset, will assume `/cyral/sidecars/<SIDECAR_ID>/secrets`."
+  SecretArn:
+    Description: "(Optional) ARN of the secret with the credentials used by the sidecar."
+    Type: String
+    Default: ""
+
+  SecretRoleArn:
+    Description: "(Optional) ARN of an AWS IAM Role to assume when reading the secret informed in `SecretArn`."
     Type: String
     Default: ""
 
@@ -231,7 +224,7 @@ Parameters:
 
   CustomTag:
     Type: String
-    Description: (Optional) Custom tag to be added in the sidecar resources. Ex:"key=value".
+    Description: "(Optional) Custom tag to be added in the sidecar resources. Ex: \"key=value\"."
     Default: ""
     AllowedPattern: "^([0-9a-zA-Z]+=[0-9a-zA-Z]+|)$"
 
@@ -239,18 +232,15 @@ Parameters:
     Type: String
     Description: "Prefix for names of the AWS resources created. Maximum length is 24 characters."
 
-  UseSingleContainer:
-    Description: "Use single container for sidecar deployment"
-    Type: "String"
-    Default: "false"
-    AllowedValues:
-      - "true"
-      - "false"
-
   IAMPolicies:
     Type: CommaDelimitedList
-    Description: (Optional) List of IAM policies ARNs that will be attached to the sidecar IAM role (Comma Delimited List)
+    Description: "(Optional) List of IAM policies ARNs that will be attached to the sidecar IAM role (Comma Delimited List)"
     Default: ""
+
+  RepositoriesSupported:
+    Type: String
+    Description: "List of all repositories that will be supported by the sidecar (lower case only)"
+    Default: "denodo,dremio,dynamodb,mongodb,mysql,oracle,postgresql,redshift,snowflake,sqlserver,s3"
 
   CustomUserDataPre:
     Type: String
@@ -274,35 +264,36 @@ Conditions:
   mustAttachIAMPolicies: !Not [!Equals [!Join ["", !Ref IAMPolicies], ""]]
   loadBalancerCertificateArnNotEmpty: !And [!Not [!Equals [!Ref LoadBalancerCertificateArn, '']], !Condition deployLoadBalancer]
   loadBalancerCertificateArnEmpty: !And [!Equals [!Ref LoadBalancerCertificateArn, ''], !Condition deployLoadBalancer]
-  sidecarDNSNameNotEmpty: !Not [!Equals [!Ref SidecarDNSName, '']]
-  hasSecretsLocation: !Not [!Equals [!Ref SecretsLocation, '']]
-  sidecarTLSCertificateSecretArnEmpty: !Equals [!Ref SidecarTLSCertificateSecretArn, '']
-  sidecarTLSCertificateSecretArnNotEmpty: !Not [!Condition sidecarTLSCertificateSecretArnEmpty]
-  sidecarTLSCertificateRoleArnEmpty: !Equals [!Ref SidecarTLSCertificateRoleArn, '']
-  sidecarTLSCertificateRoleArnNotEmpty: !Not [!Condition sidecarTLSCertificateRoleArnEmpty]
-  sidecarTLSCertificateDoNotAssumeRole: !And
-    - !Condition sidecarTLSCertificateSecretArnNotEmpty
-    - !Condition sidecarTLSCertificateRoleArnEmpty
-  sidecarTLSCertificateMustAssumeRole: !And
-    - !Condition sidecarTLSCertificateSecretArnNotEmpty
-    - !Condition sidecarTLSCertificateRoleArnNotEmpty
+  dnsNameNotEmpty: !Not [!Equals [!Ref DNSName, '']]
+  hasSecretArn: !Not [!Equals [!Ref SecretArn, '']]
+  hasNamePrefix: !Not [!Equals [!Ref NamePrefix, '']]
+  tlsCertificateSecretArnEmpty: !Equals [!Ref TLSCertificateSecretArn, '']
+  tlsCertificateSecretArnNotEmpty: !Not [!Condition tlsCertificateSecretArnEmpty]
+  tlsCertificateRoleArnEmpty: !Equals [!Ref TLSCertificateRoleArn, '']
+  tlsCertificateRoleArnNotEmpty: !Not [!Condition tlsCertificateRoleArnEmpty]
+  tlsCertificateDoNotAssumeRole: !And
+    - !Condition tlsCertificateSecretArnNotEmpty
+    - !Condition tlsCertificateRoleArnEmpty
+  tlsCertificateMustAssumeRole: !And
+    - !Condition tlsCertificateSecretArnNotEmpty
+    - !Condition tlsCertificateRoleArnNotEmpty
 
-  sidecarCACertificateSecretArnEmpty: !Equals [!Ref SidecarCACertificateSecretArn, '']
-  sidecarCACertificateSecretArnNotEmpty: !Not [!Condition sidecarCACertificateSecretArnEmpty]
-  sidecarCACertificateRoleArnEmpty: !Equals [!Ref SidecarCACertificateRoleArn, '']
-  sidecarCACertificateRoleArnNotEmpty: !Not [!Condition sidecarCACertificateRoleArnEmpty]
-  sidecarCACertificateDoNotAssumeRole: !And
-    - !Condition sidecarCACertificateSecretArnNotEmpty
-    - !Condition sidecarCACertificateRoleArnEmpty
-  sidecarCACertificateMustAssumeRole: !And
-    - !Condition sidecarCACertificateSecretArnNotEmpty
-    - !Condition sidecarCACertificateRoleArnNotEmpty
+  caCertificateSecretArnEmpty: !Equals [!Ref CACertificateSecretArn, '']
+  caCertificateSecretArnNotEmpty: !Not [!Condition caCertificateSecretArnEmpty]
+  caCertificateRoleArnEmpty: !Equals [!Ref CACertificateRoleArn, '']
+  caCertificateRoleArnNotEmpty: !Not [!Condition caCertificateRoleArnEmpty]
+  caCertificateDoNotAssumeRole: !And
+    - !Condition caCertificateSecretArnNotEmpty
+    - !Condition caCertificateRoleArnEmpty
+  caCertificateMustAssumeRole: !And
+    - !Condition caCertificateSecretArnNotEmpty
+    - !Condition caCertificateRoleArnNotEmpty
 
 Resources:
   CloudwatchLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Ref NamePrefix
+      LogGroupName: !If [hasNamePrefix, !Join ["-", ["cyral", !Ref NamePrefix]], "cyral-sidecar"]
       RetentionInDays: 14
       Tags:
         - Key: "Stack"
@@ -358,7 +349,7 @@ Resources:
             - "GroupTotalInstances"
       Tags:
         - Key: "Name"
-          Value: !Join ["-", [!Ref NamePrefix, "sidecar"]]
+          Value: !If [hasNamePrefix, !Join ["-", ["cyral", !Ref NamePrefix]], "cyral"]
           PropagateAtLaunch: true
         - Key: "SidecarVersion"
           Value: !Ref SidecarVersion
@@ -426,10 +417,10 @@ Resources:
             Resource:
               - !Sub 'arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/cyral/*'
               - !Sub
-                - 'arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${secrets_location}*'
-                - secrets_location: !If [hasSecretsLocation, !Ref SecretsLocation, !Sub '/cyral/sidecars/${SidecarId}/secrets']
-              - !If [sidecarTLSCertificateDoNotAssumeRole, !Ref SidecarTLSCertificateSecretArn, !Ref AWS::NoValue]
-              - !If [sidecarCACertificateDoNotAssumeRole, !Ref SidecarCACertificateSecretArn, !Ref AWS::NoValue]
+                - 'arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${secret_arn}*'
+                - secret_arn: !If [hasSecretArn, !Ref SecretArn, !Ref SMSidecarSecret]
+              - !If [tlsCertificateDoNotAssumeRole, !Ref TLSCertificateSecretArn, !Ref AWS::NoValue]
+              - !If [caCertificateDoNotAssumeRole, !Ref CACertificateSecretArn, !Ref AWS::NoValue]
             Effect: Allow
           - Action:
               - "ecr:GetAuthorizationToken"
@@ -441,18 +432,18 @@ Resources:
             Resource: !Sub "arn:${AWS::Partition}:ecr:*:${AWS::AccountId}:repository/*"
             Effect: Allow
           - Fn::If:
-            - sidecarTLSCertificateMustAssumeRole
+            - tlsCertificateMustAssumeRole
             - Effect: Allow
               Action:
                 - sts:AssumeRole
-              Resource: !Ref SidecarTLSCertificateRoleArn
+              Resource: !Ref TLSCertificateRoleArn
             - !Ref AWS::NoValue
           - Fn::If:
-            - sidecarCACertificateMustAssumeRole
+            - caCertificateMustAssumeRole
             - Effect: Allow
               Action:
                 - sts:AssumeRole
-              Resource: !Ref SidecarCACertificateRoleArn
+              Resource: !Ref CACertificateRoleArn
             - !Ref AWS::NoValue
       Roles:
         - !Ref SidecarHostRole
@@ -506,13 +497,6 @@ Resources:
                     echo "Updating and installing packages..."
                     yum update -y
                     yum install -y aws-cfn-bootstrap wget ec2-instance-connect docker jq
-                }
-
-                function docker_compose_install(){
-                    # Compose Setup
-                    sudo mkdir -p /usr/local/lib/docker/cli-plugins/
-                    sudo curl -SsfL https://github.com/docker/compose/releases/latest/download/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
-                    sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
                 }
 
                 function docker_setup(){
@@ -586,23 +570,21 @@ Resources:
 
                 function get_secret(){
                     echo "Fetching Secret..."
-                    if ! secret=$(aws secretsmanager get-secret-value --secret-id "${secrets_location}" --query SecretString --output text --region "${AWS::Region}" 2>&1); then
-                        echo "Unable to fetch secret ${secrets_location}"
-                        echo "Error: $secret"
+                    if ! secret=$(get_secret_value "${secret_arn}" "${secret_role_arn}"); then
+                        echo "ERROR: Unable to fetch sidecar secrets from ${secret_arn} see error above"
                         exit 1
                     fi
                     SIDECAR_CLIENT_ID=$(echo "$secret" | jq -r .clientId)
                     SIDECAR_CLIENT_SECRET=$(echo "$secret" | jq -r .clientSecret)
-                    GCR_REG_KEY=$(echo "$secret" | jq -r .containerRegistryKey)
                 }
 
                 function load_certs() {
                     echo "Loading certificates..."
                     local sidecar_tls_cert_secret_value sidecar_ca_cert_secret_value
-                    if ! sidecar_tls_cert_secret_value=$(get_secret_value "${sidecar_tls_certificate_secret_arn}" "${SidecarTLSCertificateRoleArn}"); then
+                    if ! sidecar_tls_cert_secret_value=$(get_secret_value "${sidecar_tls_certificate_secret_arn}" "${TLSCertificateRoleArn}"); then
                       echo "WARNING: Unable to fetch shared TLS certificate from ${sidecar_tls_certificate_secret_arn} see error above"
                     fi
-                    if ! sidecar_ca_cert_secret_value=$(get_secret_value "${sidecar_ca_certificate_secret_arn}" "${SidecarCACertificateRoleArn}"); then
+                    if ! sidecar_ca_cert_secret_value=$(get_secret_value "${sidecar_ca_certificate_secret_arn}" "${CACertificateRoleArn}"); then
                       echo "WARNING: Unable to fetch shared CA certificate from ${sidecar_ca_certificate_secret_arn}" see error above.
                     fi
                     SIDECAR_TLS_KEY=$(echo "$sidecar_tls_cert_secret_value" | extract_key_from_json_input | base64 -w 0)
@@ -659,39 +641,11 @@ Resources:
                     SIDECAR_VERSION=$(echo "$resp" | jq -r '.sidecar.version // empty')
                 }
 
-                function download_sidecar () {
-                    local access_token url
-                    echo "Downloading Sidecar Compose File..."
-                    get_token "443"
-                    if [[ $token_error -ne 0 ]]; then
-                        error_443="$token"
-                        get_token "8000"
-                        if [[ $token_error -ne 0 ]]; then
-                            echo "Unable to retrieve token!!"
-                            echo "Attempt on 443: $error_443"
-                            echo "Attempt on 8000: $token"
-                            return 1
-                        fi
-                    fi
-                    access_token=$(echo "$token" | jq -r .access_token)
-                    url="https://${ControlPlane}/deploy/docker-compose?TemplateType=cloudformation&TemplateVersion=$SIDECAR_VERSION"
-                    echo "Trying to download the sidecar template from: $url"
-                    if ! curl -fsS --no-progress-meter -o /home/ec2-user/sidecar.compose.yaml -L "$url" -H "Authorization: Bearer $access_token" ; then
-                        echo "Unable to download compose file for version $SIDECAR_VERSION, please make sure all parameters are correct"
-                        return 1
-                    fi
-                    return 0
-                }
-
                 function registry_login () {
                     echo "Container Registry Login..."
-                    local key=$GCR_REG_KEY
                     if [[ ${ContainerRegistry} == *"amazonaws"* ]]; then
                         echo "(login): Logging in to AWS ECR..."
                         aws ecr get-login-password --region ${AWS::Region} | docker login --username AWS --password-stdin ${ContainerRegistry}
-                    elif [ -n "$key" ]; then
-                        echo "(login): Logging in to GCR..."
-                        echo "$key" | base64 --decode | docker login -u ${ContainerRegistryUsername} --password-stdin https://gcr.io
                     else
                         echo "(login): Won't log in automatically to any image registry. Image registry set to: ${ContainerRegistry}"
                     fi
@@ -714,21 +668,17 @@ Resources:
                 function launch () {
                     echo "Starting sidecar..."
                     cd /home/ec2-user
-                    if [[ ${UseSingleContainer} == "true" ]]; then
-                      SINGLE_CONTAINER_IMAGE=${ContainerRegistry}/cyral-sidecar:$SIDECAR_VERSION
-                      retry docker pull -q $SINGLE_CONTAINER_IMAGE
-                      retry docker run -d --name sidecar --network=host --log-driver=local --log-opt max-size=500m --restart=unless-stopped --env-file .env $SINGLE_CONTAINER_IMAGE
-                      if ! containerCheck "sidecar"; then
-                        echo "--> Problem with sidecar! Inspect the logs to diagnose the issue. <--"
-                      fi
-                    else
-                      retry docker compose -f sidecar.compose.yaml pull -q
-                      retry docker compose -f sidecar.compose.yaml up -d
+                    SIDECAR_IMAGE=${ContainerRegistry}/cyral-sidecar:$SIDECAR_VERSION
+                    retry docker pull -q $SIDECAR_IMAGE
+                    retry docker run -d --name sidecar --network=host --log-driver=local --log-opt max-size=500m --restart=unless-stopped --env-file .env $SIDECAR_IMAGE
+                    if ! containerCheck "sidecar"; then
+                      echo "--> Problem with sidecar! Inspect the logs to diagnose the issue. <--"
                     fi
                 }
-              - sidecar_tls_certificate_secret_arn: !If [sidecarTLSCertificateSecretArnNotEmpty, !Ref SidecarTLSCertificateSecretArn, '']
-                sidecar_ca_certificate_secret_arn: !If [sidecarCACertificateSecretArnNotEmpty, !Ref SidecarCACertificateSecretArn, '']
-                secrets_location: !If [hasSecretsLocation, !Ref SecretsLocation, !Sub '/cyral/sidecars/${SidecarId}/secrets']
+              - sidecar_tls_certificate_secret_arn: !If [tlsCertificateSecretArnNotEmpty, !Ref TLSCertificateSecretArn, '']
+                sidecar_ca_certificate_secret_arn: !If [caCertificateSecretArnNotEmpty, !Ref CACertificateSecretArn, '']
+                secret_arn: !If [hasSecretArn, !Ref SecretArn, !Ref SMSidecarSecret]
+                secret_role_arn: !Ref SecretRoleArn
             pre:
               !Sub
               - |
@@ -798,20 +748,10 @@ Resources:
                 echo "Sidecar version: $SIDECAR_VERSION"
 
                 docker_setup
-                if [[ ${UseSingleContainer} == "true" ]]; then
-                  echo "Skipping Docker Compose Install, not required for single container"
-                else
-                  docker_compose_install
-                fi
                 update_nginx_resolver
                 load_certs
                 load_idp_certs
                 registry_login
-                if [[ ${UseSingleContainer} == "true" ]]; then
-                  echo "Skipping Download Sidecar Compose File, not required for single container"
-                else
-                  retry download_sidecar
-                fi
 
                 CYRAL_SIDECAR_ENDPOINT="${sidecar_endpoint}"
                 if [ -z "$CYRAL_SIDECAR_ENDPOINT" ]; then
@@ -821,53 +761,54 @@ Resources:
                         http://169.254.169.254/latest/meta-data/public-ipv4 || (hostname -I 2>/dev/null || echo "manually-set-endpoint") | awk '{print $1}')
                 fi
 
-                # Initializing environment variables
-                env_var=$(cat <<EOF
-                SIDECAR_VERSION=$SIDECAR_VERSION
+                echo "Sidecar endpoint: $CYRAL_SIDECAR_ENDPOINT"
+
+                echo "Initializing environment variables..."
+                cat > /home/ec2-user/.env << EOF
+
                 IS_DYNAMIC_VERSION=$IS_DYNAMIC_VERSION
                 IS_RECYCLABLE=true
-                CONTROLPLANE_HOST=${ControlPlane}
-                CONTAINER_REGISTRY=${ContainerRegistry}
-                METRICS_PORT=9000
-                SIDECAR_ENDPOINT=${sidecar_endpoint}
-                CLOUD_PROVIDER=AWS
+
                 AWS_REGION=${AWS::Region}
                 AWS_ACCOUNT_ID=${AWS::AccountId}
-                INSTANCE_ID=$INSTANCE_ID
-                LOG_GROUP_NAME=${log_group}
-                NGINX_RESOLVER=$NGINX_RESOLVER
-                SECRETS_LOCATION=${secrets_location}
+                LOG_GROUP_NAME=${log_group_name}
+
                 TLS_SKIP_VERIFY=${tls_skip_verify}
-                SSO_LOGIN_URL=${IdPSSOLoginURL}
-                IDP_CERTIFICATE=${IdPCertificate}
-                SIDECAR_IDP_PUBLIC_CERT=${SidecarPublicIdPCertificate}
-                SIDECAR_IDP_PRIVATE_KEY=${SidecarPrivateIdPKey}
+
+                CYRAL_IDP_CERTIFICATE=${IdPCertificate}
+                CYRAL_NGINX_RESOLVER=$NGINX_RESOLVER
+                CYRAL_SSO_LOGIN_URL=${IdPSSOLoginURL}
+
+                CYRAL_SIDECAR_IDP_PUBLIC_CERT=${SidecarPublicIdPCertificate}
+                CYRAL_SIDECAR_IDP_PRIVATE_KEY=${SidecarPrivateIdPKey}
+
+                CYRAL_SIDECAR_CA_CERT=${!SIDECAR_CA_CERT}
+                CYRAL_SIDECAR_CA_PRIVATE_KEY=${!SIDECAR_CA_KEY}
+                CYRAL_SIDECAR_TLS_CERT=${!SIDECAR_TLS_CERT}
+                CYRAL_SIDECAR_TLS_PRIVATE_KEY=${!SIDECAR_TLS_KEY}
+
+                CYRAL_CONTROL_PLANE=${ControlPlane}
+
+                CYRAL_LOAD_BALANCER_TLS_PORTS=${load_balancer_tls_ports}
+
                 CYRAL_SIDECAR_ID=${SidecarId}
                 CYRAL_SIDECAR_CLIENT_ID=${!SIDECAR_CLIENT_ID}
                 CYRAL_SIDECAR_CLIENT_SECRET=${!SIDECAR_CLIENT_SECRET}
-                CYRAL_CONTROL_PLANE=${ControlPlane}
-                CYRAL_SIDECAR_VERSION=$SIDECAR_VERSION
-                CYRAL_SIDECAR_ENDPOINT=$CYRAL_SIDECAR_ENDPOINT
                 CYRAL_SIDECAR_CLOUD_PROVIDER=aws
+                CYRAL_SIDECAR_DEPLOYMENT_PROPERTIES='{ \"account-id\": \"${AWS::AccountId}\",\"region\": \"${AWS::Region}\",\"deployment-type\": \"cloudformation-ec2\"}'
+                CYRAL_SIDECAR_ENDPOINT=$CYRAL_SIDECAR_ENDPOINT
+                CYRAL_SIDECAR_INSTANCE_ID=$INSTANCE_ID
+                CYRAL_SIDECAR_VERSION=$SIDECAR_VERSION
 
-                CYRAL_SIDECAR_DEPLOYMENT_PROPERTIES='{\"account-id\": \"${AWS::AccountId}\",\"region\": \"${AWS::Region}\",\"deployment-type\": \"cloudformation-ec2\"}'
-                CYRAL_CERTIFICATE_MANAGER_TLS_KEY=${!SIDECAR_TLS_KEY}
-                CYRAL_CERTIFICATE_MANAGER_TLS_CERT=${!SIDECAR_TLS_CERT}
-                CYRAL_CERTIFICATE_MANAGER_CA_KEY=${!SIDECAR_CA_KEY}
-                CYRAL_CERTIFICATE_MANAGER_CA_CERT=${!SIDECAR_CA_CERT}
+                CYRAL_REPOSITORIES_SUPPORTED=${repositories_supported}
 
-                LOAD_BALANCER_TLS_PORTS=${load_balancer_tls_ports}
                 EOF
-                )
-                cat > /home/ec2-user/.env << EOF
-                $env_var
-                $proxy_env
-                EOF
-              - sidecar_endpoint: !If [deployLoadBalancer, !If [sidecarDNSNameNotEmpty, !Ref SidecarDNSName, !GetAtt LoadBalancer.DNSName], ""]
-                log_group: !Ref CloudwatchLogGroup
+              - sidecar_endpoint: !If [deployLoadBalancer, !If [dnsNameNotEmpty, !Ref DNSName, !GetAtt LoadBalancer.DNSName], ""]
+                log_group_name: !Ref CloudwatchLogGroup
                 tls_skip_verify: 'tls'
-                secrets_location: !If [hasSecretsLocation, !Ref SecretsLocation, !Sub '/cyral/sidecars/${SidecarId}/secrets']
+                secret_arn: !If [hasSecretArn, !Ref SecretArn, !Ref SMSidecarSecret]
                 load_balancer_tls_ports: !If [loadBalancerCertificateArnNotEmpty, 443, '']
+                repositories_supported: !Ref RepositoriesSupported
             post: |
               launch
 
@@ -878,7 +819,7 @@ Resources:
       VpcId: !Ref VpcId
       Tags:
         - Key: "Name"
-          Value: !Join ["-", [!Ref NamePrefix, "sidecar"]]
+          Value: !If [hasNamePrefix, !Join ["-", ["cyral", !Ref NamePrefix]], "cyral"]
         - Key: "Stack"
           Value: !Ref "AWS::StackName"
         - Fn::If:
@@ -951,7 +892,7 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Condition: deployLoadBalancer
     Properties:
-      Name: !Ref NamePrefix
+      Name: !If [hasNamePrefix, !Join ["-", ["cyral", !Ref NamePrefix]], "cyral"]
       Type: network
       Scheme: !Ref LoadBalancerScheme
       Subnets: !Ref Subnets
@@ -1291,8 +1232,8 @@ Resources:
     Type: AWS::SecretsManager::Secret
     Properties:
       Description: Cyral Sidecar secret with client id, secret and container registry key.
-      Name: !If [hasSecretsLocation, !Ref SecretsLocation, !Sub '/cyral/sidecars/${SidecarId}/secrets']
-      SecretString: !Sub '{"clientId":"${ClientId}", "clientSecret": "${ClientSecret}", "containerRegistryKey": "${ContainerRegistryKey}", "sidecarPublicIdpCertificate": "${SidecarPublicIdPCertificate}", "sidecarPrivateIdpKey": "${SidecarPrivateIdPKey}"}'
+      Name: !If [hasSecretArn, !Ref SecretArn, !Sub '/cyral/sidecars/${SidecarId}/secrets']
+      SecretString: !Sub '{"clientId":"${ClientId}", "clientSecret": "${ClientSecret}", "sidecarPublicIdpCertificate": "${SidecarPublicIdPCertificate}", "sidecarPrivateIdpKey": "${SidecarPrivateIdPKey}"}'
       KmsKeyId: !Ref AWS::NoValue
       Tags:
         - Key: "Stack"
@@ -1318,4 +1259,4 @@ Outputs:
 
   SidecarNameIdentifier:
     Description: Identifier used to create various AWS resources such as EC2 Name and CloudWatch Log Group Name
-    Value: !Ref NamePrefix
+    Value: !If [hasNamePrefix, !Join ["-", ["cyral", !Ref NamePrefix]], "cyral"]

--- a/docs/byos.md
+++ b/docs/byos.md
@@ -1,0 +1,40 @@
+# Bring Your Own Secret
+
+You can create your own secret and provide it as an input parameter instead of
+letting the template manage the sidecar secrets automatically. This is tipically
+useful for customers willing to deploy the secrets to a different account
+than that used to deploy the sidecar.
+
+You can create your own secret in AWS Secrets Manager and provide its full
+ARN to parameter `SecretArn` as long as the secrets contents is a JSON
+with the following format:
+
+```JSON
+{
+    "clientId":"",
+    "clientSecret":"",
+    "idpCertificate":"",
+    "sidecarPrivateIdpKey":"",
+    "sidecarPublicIdpCertificate":""
+}
+```
+
+| Attribute                     | Required | Format |
+| :---------------------------- | :------: | ------ |
+| `clientId`                    | Yes      | String |
+| `clientSecret`                | Yes      | String |
+| `idpCertificate`              | No       | String - new lines escaped (replace `\n` by `\\n``) |
+| `sidecarPrivateIdpKey`        | No       | String - new lines escaped (replace `\n` by `\\n``) |
+| `sidecarPublicIdpCertificate` | No       | String - new lines escaped (replace `\n` by `\\n``) |
+
+Make sure to escape new line characters by replacing `\n` by `\\n` in the parameters `idpCertificate`,
+`sidecarPublicIdpCertificate` and `sidecarPrivateIdpKey` before storing them on
+your secret.
+
+In case you are creating this secret in a different account, use the input
+parameter `SecretRoleArn` to provide the ARN of the role that will be
+assumed in order to read the secret.
+
+See also:
+
+* To understand the concept of `Full ARN`, read [this page](https://docs.aws.amazon.com/secretsmanager/latest/userguide/troubleshoot.html#ARN_secretnamehyphen).

--- a/docs/certificates.md
+++ b/docs/certificates.md
@@ -116,7 +116,7 @@ This script expects a few environment variables to be set:
 
 * `AWS_DEFAULT_REGION` : This should be set to the same region where you plan to deploy your sidecar
 * `SIDECAR_ID` : This should be set to the same value you use for the `SidecarId` parameter of this [Cloudformation](../cft_sidecar.yaml) template
-* `SIDECAR_NAME` : (Optional) This should be set to the same value you use for the `DNSName` parameter of this [Cloudformation](../cft_sidecar.yaml) template. If this is not set, then the default hostname of `sidecar.cyral.app.com` will be used for the domain name on the certificates.
+* `SIDECAR_NAME` : (Optional) This should be set to the same value you use for the `DNSName` parameter of this [Cloudformation](../cft_sidecar.yaml) template. If this is not set, then the default hostname of `sidecar.app.cyral.com` will be used for the domain name on the certificates.
 
 ### Required commands
 

--- a/docs/certificates.md
+++ b/docs/certificates.md
@@ -55,8 +55,8 @@ that the following requirements are met by your private key / certificate pair:
 If you have a scenario in which you have two different accounts: one where you
 deploy the sidecar and another where you manage the sidecar secrets, then you
 can use the module inputs
-`SidecarTLSCertificateRoleArn` (for TLS certificate) or
-`SidecarCACertificateRoleArn` (for CA certificate) to the sidecar
+`TLSCertificateRoleArn` (for TLS certificate) or
+`CACertificateRoleArn` (for CA certificate) to the sidecar
 module. Suppose you have the following configuration:
 
    - Account `111111111111` used to manage secrets
@@ -70,8 +70,8 @@ module. Suppose you have the following configuration:
    documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html)
    for further information.
 
-2. Provide the ARN of `role1` to `SidecarTLSCertificateRoleArn` (for the TLS
-   certificate) or `SidecarCACertificateRoleArn` (for the CA certificate) of
+2. Provide the ARN of `role1` to `TLSCertificateRoleArn` (for the TLS
+   certificate) or `CACertificateRoleArn` (for the CA certificate) of
    the sidecar module.
 
 3. Provide the ARNs of the certificate secrets to the sidecar module, as
@@ -82,10 +82,10 @@ module. Suppose you have the following configuration:
 There are two parameters in the sidecar module you can use to provide the ARN of
 a secret containing a custom certificate:
 
-1. `SidecarTLSCertificateRoleArn` (Optional) ARN of secret in AWS Secrets
+1. `TLSCertificateRoleArn` (Optional) ARN of secret in AWS Secrets
    Manager that contains a certificate to terminate TLS connections.
 
-1. `SidecarCACertificateRoleArn` (Optional) ARN of secret in AWS Secrets
+1. `CACertificateRoleArn` (Optional) ARN of secret in AWS Secrets
    Manager that contains a CA certificate to sign sidecar-generated certs.
 
 The secrets must follow the following JSON format.
@@ -116,7 +116,7 @@ This script expects a few environment variables to be set:
 
 * `AWS_DEFAULT_REGION` : This should be set to the same region where you plan to deploy your sidecar
 * `SIDECAR_ID` : This should be set to the same value you use for the `SidecarId` parameter of this [Cloudformation](../cft_sidecar.yaml) template
-* `SIDECAR_NAME` : (Optional) This should be set to the same value you use for the `SidecarDNSName` parameter of this [Cloudformation](../cft_sidecar.yaml) template. If this is not set, then the default hostname of `sidecar.cyral.app.com` will be used for the domain name on the certificates.
+* `SIDECAR_NAME` : (Optional) This should be set to the same value you use for the `DNSName` parameter of this [Cloudformation](../cft_sidecar.yaml) template. If this is not set, then the default hostname of `sidecar.cyral.app.com` will be used for the domain name on the certificates.
 
 ### Required commands
 
@@ -130,9 +130,9 @@ This script makes use of the following commands:
 
 With the environment variables set, you can run the command to generate the certificates and create the AWS secrets. The ARN for each of the certificates are listed in the results.
 
-The ARN (`arn:aws:secretsmanager:us-east-1:222222222222:secret:/cyral/sidecars/abc123/ca-certificate-CC293L`) for the AWS Secret named `/cyral/sidecars/abc123/ca-certificate` should be used as the value for the `SidecarCACertificateSecretArn` [Cloudformation](../cft_sidecar.yaml) template parameter.
+The ARN (`arn:aws:secretsmanager:us-east-1:222222222222:secret:/cyral/sidecars/abc123/ca-certificate-CC293L`) for the AWS Secret named `/cyral/sidecars/abc123/ca-certificate` should be used as the value for the `CACertificateSecretArn` [Cloudformation](../cft_sidecar.yaml) template parameter.
 
-The ARN (`arn:aws:secretsmanager:us-east-1:222222222222:secret:/cyral/sidecars/abc123/self-signed-certificate-A27IAy`) for the AWS Secret named `/cyral/sidecars/abc123/self-signed-certificate` should be used as the value for the `SidecarCreatedCertificateSecretArn` [Cloudformation](../cft_sidecar.yaml) template parameter.
+The ARN (`arn:aws:secretsmanager:us-east-1:222222222222:secret:/cyral/sidecars/abc123/self-signed-certificate-A27IAy`) for the AWS Secret named `/cyral/sidecars/abc123/self-signed-certificate` should be used as the value for the `TLSCertificateSecretArn` [Cloudformation](../cft_sidecar.yaml) template parameter.
 
 
 ```shell
@@ -190,9 +190,9 @@ This script makes use of the following commands:
 
 With the environment variables set and files created, you can run the command to import the certificates and create the AWS secrets. The ARN for each of the certificates are listed in the results.
 
-The ARN (`arn:aws:secretsmanager:us-east-1:222222222222:secret:/cyral/sidecars/abc123/ca-certificate-CC293L`) for the AWS Secret named `/cyral/sidecars/abc123/ca-certificate` should be used as the value for the `SidecarCACertificateSecretArn` [Cloudformation](../cft_sidecar.yaml) template parameter.
+The ARN (`arn:aws:secretsmanager:us-east-1:222222222222:secret:/cyral/sidecars/abc123/ca-certificate-CC293L`) for the AWS Secret named `/cyral/sidecars/abc123/ca-certificate` should be used as the value for the `CACertificateSecretArn` [Cloudformation](../cft_sidecar.yaml) template parameter.
 
-The ARN (`arn:aws:secretsmanager:us-east-1:222222222222:secret:/cyral/sidecars/abc123/self-signed-certificate-A27IAy`) for the AWS Secret named `/cyral/sidecars/abc123/self-signed-certificate` should be used as the value for the `SidecarCreatedCertificateSecretArn` [Cloudformation](../cft_sidecar.yaml) template parameter.
+The ARN (`arn:aws:secretsmanager:us-east-1:222222222222:secret:/cyral/sidecars/abc123/self-signed-certificate-A27IAy`) for the AWS Secret named `/cyral/sidecars/abc123/self-signed-certificate` should be used as the value for the `TLSCertificateSecretArn` [Cloudformation](../cft_sidecar.yaml) template parameter.
 
 
 ```shell

--- a/docs/s3-browser.md
+++ b/docs/s3-browser.md
@@ -2,7 +2,7 @@
 
 To configure the sidecar to work on the S3 File Browser, set the following parameters in your CloudFormation stack:
 
-  - `SidecarDNSName`: Add the sidecar custom CNAME.
+  - `DNSName`: Add the sidecar custom CNAME.
   - `LoadBalancerCertificateArn`: Add the ARN of the TLS certificate in
     AWS Certificate Manager.
 

--- a/scripts/generate_certificates.sh
+++ b/scripts/generate_certificates.sh
@@ -119,8 +119,8 @@ fi
 check_for_secrets $AWS_DEFAULT_REGION $SIDECAR_ID
 
 # Create the Secrets in AWS
-SidecarCreatedCertificateSecretArn=$(create_secret "/cyral/sidecars/$SIDECAR_ID/self-signed-certificate" 'TLS certificate needed by the sidecar to terminate TLS connections' $AWS_DEFAULT_REGION)
-SidecarCACertificateSecretArn=$(create_secret "/cyral/sidecars/$SIDECAR_ID/ca-certificate" 'TLS certificate needed by the sidecar to terminate TLS connections' $AWS_DEFAULT_REGION)
+CreatedCertificateSecretArn=$(create_secret "/cyral/sidecars/$SIDECAR_ID/self-signed-certificate" 'TLS certificate needed by the sidecar to terminate TLS connections' $AWS_DEFAULT_REGION)
+CACertificateSecretArn=$(create_secret "/cyral/sidecars/$SIDECAR_ID/ca-certificate" 'TLS certificate needed by the sidecar to terminate TLS connections' $AWS_DEFAULT_REGION)
 
 # Generate certificates and store them in the secret
-generate_certificates $SIDECAR_NAME $SidecarCreatedCertificateSecretArn $SidecarCACertificateSecretArn $aws_region
+generate_certificates $SIDECAR_NAME $TLSCertificateSecretArn $CACertificateSecretArn $aws_region

--- a/scripts/import_certificates.sh
+++ b/scripts/import_certificates.sh
@@ -105,8 +105,8 @@ fi
 check_for_secrets $AWS_DEFAULT_REGION $SIDECAR_ID
 
 # Create the Secrets in AWS
-SidecarCreatedCertificateSecretArn=$(create_secret "/cyral/sidecars/$SIDECAR_ID/self-signed-certificate" 'TLS certificate needed by the sidecar to terminate TLS connections' $AWS_DEFAULT_REGION)
-SidecarCACertificateSecretArn=$(create_secret "/cyral/sidecars/$SIDECAR_ID/ca-certificate" 'TLS certificate needed by the sidecar to terminate TLS connections' $AWS_DEFAULT_REGION)
+TLSCertificateSecretArn=$(create_secret "/cyral/sidecars/$SIDECAR_ID/self-signed-certificate" 'TLS certificate needed by the sidecar to terminate TLS connections' $AWS_DEFAULT_REGION)
+CACertificateSecretArn=$(create_secret "/cyral/sidecars/$SIDECAR_ID/ca-certificate" 'TLS certificate needed by the sidecar to terminate TLS connections' $AWS_DEFAULT_REGION)
 
 # Generate certificates and store them in the secret
-import_certificates $SIDECAR_NAME $SidecarCreatedCertificateSecretArn $SidecarCACertificateSecretArn $aws_region
+import_certificates $SIDECAR_NAME $TLSCertificateSecretArn $CACertificateSecretArn $aws_region


### PR DESCRIPTION
This PR introduces the following changes:

1. Move to single container sidecar.
2. Align the initialization scripts and variable names to the AWS Terraform EC2 version.
3. Fix a condition that would lead to a failure reading external secrets.
4. Add documentation for "Bring your own secret".